### PR TITLE
Set exporter image tag to v7.5.x.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ kibana-exporter -kibana.uri http://localhost:5601 -web.telemetry-path "/scrape"
 The Docker Image `chamilad/kibana-prometheus-exporter` can be used directly to run the exporter in a Dockerized environment. The Container filesystem only contains the statically linked binary, so that it can be run independently. 
 
 ```bash
-docker run -p 9684:9684 -it chamilad/kibana-prometheus-exporter:v7.5.x.2-latest -kibana.username elastic -kibana.password password -kibana.uri https://elasticcloud.kibana.aws.found.io
+docker run -p 9684:9684 -it chamilad/kibana-prometheus-exporter:v7.5.x.1 -kibana.username elastic -kibana.password password -kibana.uri https://elasticcloud.kibana.aws.found.io
 ```
 
 Refer to the [Makefile](Makefile) and the [Dockerfile](Dockerfile) for more details.

--- a/k8s/kibana-prometheus-exporter.yaml
+++ b/k8s/kibana-prometheus-exporter.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: kibana-prometheus-exporter
-        image: chamilad/kibana-prometheus-exporter:v7.5.x.2-latest
+        image: chamilad/kibana-prometheus-exporter:v7.5.x.1
         args: [
           "-kibana.uri", "http://kibana:5601",
         ]


### PR DESCRIPTION
Trying to deploy exporter in K8s gives an error:

```
Warning  Failed     0s (x2 over 17s)  kubelet, my-node2  Failed to pull image "chamilad/kibana-prometheus-exporter:v7.5.x.2-latest": rpc error: code = Unknown desc = Error response from daemon: manifest for chamilad/kibana-prometheus-exporter:v7.5.x.2-latest not found
  Warning  Failed     0s (x2 over 17s)  kubelet, my-node2  Error: ErrImagePull
```

There is only one tag currently available in [docker-hub](https://hub.docker.com/r/chamilad/kibana-prometheus-exporter/tags): `v7.5.x.1`.

P.S works like a magic for Kibana `v6.7.1` 👍 