### PR TITLE
Add flag to skip TLS verification for Kibana

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,5 @@ README.md
 
 *.swp
 
+tmp/
+

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build/
 .idea/
 *.swp
 
+# temp
+tmp/

--- a/README.md
+++ b/README.md
@@ -19,12 +19,17 @@ By default, the Exporter exposes the `/metrics` endpoint at port `9684`. If need
 
 ```bash
 # expose the /metrics endpoint at port 8080
-kibana-exporter -kibana.uri http://localhost:5601 -web.listen-address 8080 
+kibana-exporter -kibana.uri http://localhost:5601 -web.listen-address :8080 
 ```
 
 ```bash
 # expose metrics using /scrape endpint
 kibana-exporter -kibana.uri http://localhost:5601 -web.telemetry-path "/scrape"
+```
+
+```bash
+# skip TLS verification for self-signed Kibana certificates
+kibana-exporter -kibana.uri https://kibana.local:5601 -kibana.skip-tls true
 ```
 
 ### Docker 
@@ -109,6 +114,7 @@ The metrics exposed by this Exporter are the following.
 3. Add more metrics related to the scrape job itself
 4. Add a Grafana dashboards with (Prometheus) alerts 
 5. Add mTLS to the metrics server
+6. Add an initial connection test and fail early
 
 ## Contributing
 More metrics, useful tweaks, samples, bug fixes, and any other form of contributions are welcome. Please fork, modify, and open a PR. Please open a GitHub issue for observed bugs or feature requests. I will try to attend to them when possible.

--- a/etc/elk-certs.yml
+++ b/etc/elk-certs.yml
@@ -1,0 +1,5 @@
+# config to generate a self signed cert for elasticsearch
+instances:
+  - name: "kibana"
+    dns: [ "kibana.local" ]
+

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNewExporterUnauthenticated(t *testing.T) {
-	err, exporter := NewExporter("http://localhost:5601", "", "", "kibana_test")
+	err, exporter := NewExporter("http://localhost:5601", "", "", "kibana_test", false)
 	if err != nil {
 		t.Errorf("NewExporter failed with valid input")
 	}
@@ -16,7 +16,7 @@ func TestNewExporterUnauthenticated(t *testing.T) {
 }
 
 func TestNewExporterUnauthenticatedWithOnlyUsername(t *testing.T) {
-	err, exporter := NewExporter("http://localhjost:5601", "someusername", "", "kibana_test")
+	err, exporter := NewExporter("http://localhjost:5601", "someusername", "", "kibana_test", false)
 	if err != nil {
 		t.Errorf("NewExporter failed with valid input")
 	}
@@ -27,7 +27,7 @@ func TestNewExporterUnauthenticatedWithOnlyUsername(t *testing.T) {
 }
 
 func TestNewExporterUnauthenticatedWithOnlyPassword(t *testing.T) {
-	err, exporter := NewExporter("http://localhjost:5601", "", "somepassword", "kibana_test")
+	err, exporter := NewExporter("http://localhjost:5601", "", "somepassword", "kibana_test", false)
 	if err != nil {
 		t.Errorf("NewExporter failed with valid input")
 	}
@@ -38,7 +38,7 @@ func TestNewExporterUnauthenticatedWithOnlyPassword(t *testing.T) {
 }
 
 func TestNewExporterWithoutNamespace(t *testing.T) {
-	err, _ := NewExporter("http://localhost:5601", "", "", "")
+	err, _ := NewExporter("http://localhost:5601", "", "", "", false)
 	if err == nil {
 		t.Errorf("expected error when invalid namespace was provided")
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	kibanaUri      = flag.String("kibana.uri", "", "The Kibana API to fetch metrics from")
 	kibanaUsername = flag.String("kibana.username", "", "The username to use for Kibana API")
 	kibanaPassword = flag.String("kibana.password", "", "The password to use for Kibana API")
+	kibanaSkipTls  = flag.Bool("kibana.skip-tls", false, "Skip TLS verification for TLS secured Kibana URLs")
 	namespace      = "kibana"
 )
 
@@ -33,7 +34,7 @@ func main() {
 
 	log.Printf("using Kibana URL: %s", *kibanaUri)
 
-	err, exporter := exporter.NewExporter(*kibanaUri, *kibanaUsername, *kibanaPassword, namespace)
+	err, exporter := exporter.NewExporter(*kibanaUri, *kibanaUsername, *kibanaPassword, namespace, *kibanaSkipTls)
 	if err != nil {
 		log.Fatal("error while initializing exporter: ", err)
 		os.Exit(1)


### PR DESCRIPTION
This resolves #2

The flag was tested manually with a local setup generated following documentation at https://www.elastic.co/blog/configuring-ssl-tls-and-https-to-secure-elasticsearch-kibana-beats-and-logstash. 