### PR TITLE
fix(7.10): chamilad/kibana-prometheus-exporter#7

### DIFF
--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -64,7 +64,7 @@ type KibanaMetrics struct {
 // provided by the KibanaCollector struct, and return the metrics as a
 // KibanaMetrics representation.
 func (c *KibanaCollector) scrape() (error, *KibanaMetrics) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/status?extended", c.url), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/status", c.url), nil)
 	if err != nil {
 		return errors.New(fmt.Sprintf("could not initialize a request to scrape metrics: %s", err)), nil
 	}


### PR DESCRIPTION
Make it work with 7.10 (tested against 7.10.2)

In addition to the usual go/process metrics, we would get the following:

```
# HELP kibana_concurrent_connections Kibana Concurrent Connections
# TYPE kibana_concurrent_connections gauge
kibana_concurrent_connections 1
# HELP kibana_heap_max_in_bytes Kibana Heap maximum in bytes
# TYPE kibana_heap_max_in_bytes gauge
kibana_heap_max_in_bytes 1.77225728e+08
# HELP kibana_heap_used_in_bytes Kibana Heap usage in bytes
# TYPE kibana_heap_used_in_bytes gauge
kibana_heap_used_in_bytes 1.42202568e+08
# HELP kibana_millis_uptime Kibana uptime in milliseconds
# TYPE kibana_millis_uptime gauge
kibana_millis_uptime 7.5229338e+07
# HELP kibana_os_load_15m Kibana load average 15m
# TYPE kibana_os_load_15m gauge
kibana_os_load_15m 3.3916015625
# HELP kibana_os_load_1m Kibana load average 1m
# TYPE kibana_os_load_1m gauge
kibana_os_load_1m 4.83837890625
# HELP kibana_os_load_5m Kibana load average 5m
# TYPE kibana_os_load_5m gauge
kibana_os_load_5m 3.90966796875
# HELP kibana_requests_disconnects Kibana request disconnections count
# TYPE kibana_requests_disconnects gauge
kibana_requests_disconnects 0
# HELP kibana_requests_total Kibana total request count
# TYPE kibana_requests_total gauge
kibana_requests_total 1
# HELP kibana_response_average Kibana average response time in milliseconds
# TYPE kibana_response_average gauge
kibana_response_average 12
# HELP kibana_response_max Kibana maximum response time in milliseconds
# TYPE kibana_response_max gauge
kibana_response_max 12
# HELP kibana_status Kibana overall status
# TYPE kibana_status gauge
kibana_status 1
```

FYI: upstream (pjhampton) as been fixed last week.