### PR TITLE
Add flag to block until Kibana comes up

### DIFF
--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -63,10 +63,10 @@ type KibanaMetrics struct {
 // scrape will connect to the Kibana instance, using the details
 // provided by the KibanaCollector struct, and return the metrics as a
 // KibanaMetrics representation.
-func (c *KibanaCollector) scrape() (error, *KibanaMetrics) {
+func (c *KibanaCollector) scrape() (*KibanaMetrics, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/status", c.url), nil)
 	if err != nil {
-		return errors.New(fmt.Sprintf("could not initialize a request to scrape metrics: %s", err)), nil
+		return nil, errors.New(fmt.Sprintf("could not initialize a request to scrape metrics: %s", err))
 	}
 
 	if c.authHeader != "" {
@@ -77,26 +77,26 @@ func (c *KibanaCollector) scrape() (error, *KibanaMetrics) {
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.New(fmt.Sprintf("error while reading Kibana status: %s", err)), nil
+		return nil, errors.New(fmt.Sprintf("error while reading Kibana status: %s", err))
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.New(fmt.Sprintf("invalid response from Kibana status: %s", resp.Status)), nil
+		return nil, errors.New(fmt.Sprintf("invalid response from Kibana status: %s", resp.Status))
 
 	}
 
 	respContent, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return errors.New(fmt.Sprintf("error while reading response from Kibana status: %s", err)), nil
+		return nil, errors.New(fmt.Sprintf("error while reading response from Kibana status: %s", err))
 	}
 
 	metrics := &KibanaMetrics{}
 	err = json.Unmarshal(respContent, &metrics)
 	if err != nil {
-		return errors.New(fmt.Sprintf("error while unmarshalling Kibana status: %s\nProblematic content:\n%s", err, respContent)), nil
+		return nil, errors.New(fmt.Sprintf("error while unmarshalling Kibana status: %s\nProblematic content:\n%s", err, respContent))
 	}
 
-	return nil, metrics
+	return metrics, nil
 }

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNewExporterUnauthenticated(t *testing.T) {
-	err, exporter := NewExporter("http://localhost:5601", "", "", "kibana_test", false, true)
+	exporter, err := NewExporter("http://localhost:5601", "", "", "kibana_test", false, true)
 	if err != nil {
 		t.Errorf("NewExporter failed with valid input")
 	}
@@ -16,7 +16,7 @@ func TestNewExporterUnauthenticated(t *testing.T) {
 }
 
 func TestNewExporterUnauthenticatedWithOnlyUsername(t *testing.T) {
-	err, exporter := NewExporter("http://localhjost:5601", "someusername", "", "kibana_test", false, true)
+	exporter, err := NewExporter("http://localhjost:5601", "someusername", "", "kibana_test", false, true)
 	if err != nil {
 		t.Errorf("NewExporter failed with valid input")
 	}
@@ -27,7 +27,7 @@ func TestNewExporterUnauthenticatedWithOnlyUsername(t *testing.T) {
 }
 
 func TestNewExporterUnauthenticatedWithOnlyPassword(t *testing.T) {
-	err, exporter := NewExporter("http://localhjost:5601", "", "somepassword", "kibana_test", false, true)
+	exporter, err := NewExporter("http://localhjost:5601", "", "somepassword", "kibana_test", false, true)
 	if err != nil {
 		t.Errorf("NewExporter failed with valid input")
 	}
@@ -38,7 +38,7 @@ func TestNewExporterUnauthenticatedWithOnlyPassword(t *testing.T) {
 }
 
 func TestNewExporterWithoutNamespace(t *testing.T) {
-	err, _ := NewExporter("http://localhost:5601", "", "", "", false, true)
+	_, err := NewExporter("http://localhost:5601", "", "", "", false, true)
 	if err == nil {
 		t.Errorf("expected error when invalid namespace was provided")
 	}


### PR DESCRIPTION
This flag was to address the need to fail early, however it evolved into
a blocking wait since a fail early wouldn't provide much of a benefit in
a CMS where a state machine would just start another Container if there
is only a failure, resuling in a crash loopback.

The flag is set to false by default, however I'm not sure if this should
be enabled by default. The more I think of it, enabling it by default
would be more beneficial. Maybe in the next major release.

This resolves #11 