### PR TITLE
Add cosign based binary signing

### DIFF
--- a/.github/workflows/build-on-tag.yml
+++ b/.github/workflows/build-on-tag.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./github/workflows/composite-linter
+      - uses: ./.github/workflows/composite-linter
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-on-tag.yml
+++ b/.github/workflows/build-on-tag.yml
@@ -19,17 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.19
-
-      - name: Fmt
-        run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: ./github/workflows/composite-linter
 
   test:
     runs-on: ubuntu-latest
@@ -73,11 +63,23 @@ jobs:
           mkdir -p outputs/
           go build -ldflags "-extldflags '-static' -s -w" -a -o outputs/${{ env.BINARY_NAME }}-${TAG_NAME}-${GOOS}-${GOARCH}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+
+      - name: Sign the images with GitHub OIDC Token **not production ready**
+        run: cosign sign-blob --yes outputs/${{ env.BINARY_NAME }}-${TAG_NAME}-${GOOS}-${GOARCH} > outputs/${{ env.BINARY_NAME }}-${TAG_NAME}-${GOOS}-${GOARCH}.sig
+
       - name: Upload build artefact
         uses: actions/upload-artifact@v3
         with:
           path: outputs/${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}
           name: ${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}
+
+      - name: Upload signature artefact
+        uses: actions/upload-artifact@v3
+        with:
+          path: outputs/${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}.sig
+          name: ${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}.sig
 
   image:
     runs-on: ubuntu-latest
@@ -134,6 +136,11 @@ jobs:
         with:
           name: ${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}
 
+      - name: Download signature artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}.sig
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
@@ -148,3 +155,4 @@ jobs:
             Please refer to the [README.md ](README.md) for the usage details.
           files: |
             ${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}
+            ${{ env.BINARY_NAME }}-${{ steps.vars.outputs.tag }}-${{ env.GOOS }}-${{ env.GOARCH }}.sig

--- a/.github/workflows/composite-linter/action.yml
+++ b/.github/workflows/composite-linter/action.yml
@@ -1,0 +1,26 @@
+---
+name: Pre-commit Checks
+description: Run pre-commit checks
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.19
+
+    - name: Dependencies
+      shell: bash
+      run: go get .
+
+    - name: Install pre-commit tools
+      shell: bash
+      run: |
+        go install github.com/securego/gosec/v2/cmd/gosec@latest
+        go install honnef.co/go/tools/cmd/staticcheck@latest
+        go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
+
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./github/workflows/composite-linter
+      - uses: ./.github/workflows/composite-linter

--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -13,20 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.19
-
-      - name: Dependencies
-        run: go get .
-
-      - name: Install pre-commit tools
-        run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
-          go install honnef.co/go/tools/cmd/staticcheck@latest
-          go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
-
-      - uses: pre-commit/action@v3.0.0
+      - uses: ./github/workflows/composite-linter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,3 @@ repos:
       - id: go-staticcheck-mod
       - id: go-critic
       - id: golangci-lint-mod
-
-ci:
-  autofix_prs: false


### PR DESCRIPTION
This is to try out keyless signing with cosign for the binary. If successful the next step will be to sign the Docker images.

The linting workflow is also refactored to a reusable composite action.